### PR TITLE
Fix tracing import name and update tracing utilities

### DIFF
--- a/agento-streamlit/module1.py
+++ b/agento-streamlit/module1.py
@@ -19,7 +19,7 @@ import asyncio
 import json
 import os
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 import re
 from typing import Any, List, Dict, Optional
 
@@ -287,7 +287,7 @@ async def run_module_1(user_goal: str, output_file: str) -> Optional[Dict[str, A
     context = RunContextWrapper(context=None)
 
     module_name = "module1"
-    run_id = datetime.now().strftime("%Y%m%d%H%M%S%f")
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S%f")
     trace_processor = init_tracing(module_name=module_name, run_id=run_id)
 
     final_module_output_data_dict = None


### PR DESCRIPTION
## Summary
- correct imports for tracing processors and use timezone-aware timestamps
- refine cost calculation logic and token pricing constants
- integrate tracing in Module 1 using UTC run_id

## Testing
- `python -m py_compile agento-streamlit/streamlit_app/utils/tracing_utils.py agento-streamlit/module1.py agento-streamlit/streamlit_app/pages/2_Module_1_Criteria.py`

------
https://chatgpt.com/codex/tasks/task_e_683d53d65b448327a5ded552dc9d9e0b