### PR TITLE
Fix context manager usage

### DIFF
--- a/agento-streamlit/module1.py
+++ b/agento-streamlit/module1.py
@@ -294,7 +294,7 @@ async def run_module_1(user_goal: str, output_file: str) -> Optional[Dict[str, A
     generated_trace_files = None
 
     try:
-        async with agent_trace_context(f"{module_name}_MainWorkflow_{run_id}"):
+        with agent_trace_context(f"{module_name}_MainWorkflow_{run_id}"):
             log_info(f"Starting Module 1 with goal: {user_goal}", truncate=True)
             verbose_logger.info(f"Starting Module 1 with goal: {user_goal}")
 


### PR DESCRIPTION
## Summary
- use `with` instead of `async with` for agent trace context in module1

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dd82729b883278b488e8ccf59949c