### PR TITLE
Handle span types without model_dump

### DIFF
--- a/agento-streamlit/streamlit_app/utils/tracing_utils.py
+++ b/agento-streamlit/streamlit_app/utils/tracing_utils.py
@@ -93,8 +93,10 @@ class AgentoTraceProcessor(TracingProcessor):
 
     def on_trace_start(self, trace: Trace):
         """Called when a trace is started."""
-        if trace and trace.workflow_name:
-            self.current_workflow_name = trace.workflow_name
+        # Prefer ``workflow_name`` but fall back to ``name`` if available
+        workflow = getattr(trace, "workflow_name", getattr(trace, "name", None))
+        if workflow:
+            self.current_workflow_name = workflow
 
     def on_trace_end(self, trace: Trace):
         """Called when a trace is finished."""
@@ -109,12 +111,25 @@ class AgentoTraceProcessor(TracingProcessor):
     def on_span_end(self, span: Span):
         """Called when a span is finished. Should not block or raise exceptions."""
         try:
-            # Buffer all raw spans
-            self.raw_spans_buffer.append(span.model_dump(exclude_none=True))
+            # Buffer all raw spans; ``span`` might be a Pydantic model or a
+            # plain object depending on the Agents SDK version.
+            span_dict = None
+            if hasattr(span, "model_dump"):
+                span_dict = span.model_dump(exclude_none=True)
+            elif hasattr(span, "__dict__"):
+                try:
+                    span_dict = json.loads(json.dumps(span.__dict__, default=str))
+                except Exception:
+                    span_dict = {"span_repr": repr(span)}
+            if span_dict is not None:
+                self.raw_spans_buffer.append(span_dict)
 
-            # If a workflow name isn't set yet from trace, try to get it from span's trace context
+            # If a workflow name isn't set yet from trace, try to get it from span's trace
+            # context. Prefer ``workflow_name`` but fall back to ``name`` if present.
             if not self.current_workflow_name and hasattr(span, "trace") and span.trace:
-                self.current_workflow_name = span.trace.workflow_name
+                workflow = getattr(span.trace, "workflow_name", getattr(span.trace, "name", None))
+                if workflow:
+                    self.current_workflow_name = workflow
 
             # Check for LLM Generation Span
             is_llm_span = False


### PR DESCRIPTION
## Summary
- handle spans that aren't Pydantic models in `AgentoTraceProcessor`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683dddf9a9cc8327adc1c4ede348d653